### PR TITLE
pipとpipのパッケージのインストール+bashrcの設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,8 @@ RUN echo "set -g terminal-overrides 'xterm:colors=256'">> ~/.tmux.conf
 # Install pip packages
 RUN pip3 install feetech-servo-sdk
 RUN pip3 install readchar
+
+# Setup bashrc
+RUN echo "source /opt/ros/noetic/setup.bash" >> /home/docker/.bashrc
+RUN echo "cd /home/docker/catkin_ws; catkin build" >> /home/docker/.bashrc
+RUN echo "source /home/docker/catkin_ws/devel/setup.bash" >> /home/docker/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN apt-get install -y python3-wstool
 RUN apt-get install -y build-essential
 RUN apt-get install -y ros-noetic-desktop-full
 
+# Install pip3
+RUN apt-get install -y python3-pip
+
 # Create user and add to sudo group
 RUN useradd --user-group --create-home --shell /bin/false ${USER}
 RUN gpasswd -a ${USER} sudo
@@ -49,4 +52,8 @@ RUN mv .bashrc_tmp .bashrc
 # Set 256 color at tmux
 RUN touch ~/.tmux.conf
 RUN echo "set-option -g default-terminal screen-256color">> ~/.tmux.conf 
-RUN echo "set -g terminal-overrides 'xterm:colors=256'">> ~/.tmux.conf 
+RUN echo "set -g terminal-overrides 'xterm:colors=256'">> ~/.tmux.conf
+
+# Install pip packages
+RUN pip3 install feetech-servo-sdk
+RUN pip3 install readchar


### PR DESCRIPTION
## やったこと
- aptでpipをインストールする処理を追加
- パーケージの追加
  - feetech-servo-sdk
  - readchar(自作teleopを作るために追加)
- bashrcに追記
  - 起動時にcatkin buildとsource */setup.bashが走るように修正
  - これらをやり忘れて詰まるのを避けるため